### PR TITLE
feat: play nicely with Netlify deploy previews

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -89,7 +89,8 @@ export default {
     jsforce.browser.init({
       clientId: process.env.VUE_APP_SALESFORCE_CLIENT_ID,
       loginUrl: process.env.VUE_APP_SALESFORCE_LOGIN_URL,
-      redirectUri: process.env.VUE_APP_SALESFORCE_REDIRECT_URI,
+      redirectUri:
+        process.env.VUE_APP_SALESFORCE_REDIRECT_URI || process.env.VUE_APP_URL,
     });
     jsforce.browser.on('connect', (conn) => {
       console.log('Connected to Salesforce');

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,5 @@
+process.env.VUE_APP_URL = process.env.DEPLOY_PRIME_URL || process.env.URL;
+
 module.exports = {
-  transpileDependencies: [
-    'vuetify'
-  ]
-}
+  transpileDependencies: ['vuetify'],
+};


### PR DESCRIPTION
Closes #35.

1. Set the OAuth redirect URI to the first available of:
    1. `$VUE_APP_SALESFORCE_REDIRECT_URI` if set explicitly;
    2. `$DEPLOY_PRIME_URL` in a Netlify deploy preview; or
    3. `$URL` in a Netlify deployment.
2. Whichever is used in (1) must be set in Salesforce as:
    1. one of the the connected app's OAuth callback URLs; and
    2. a CORS allowed origin.